### PR TITLE
Handled negative scenarios cases

### DIFF
--- a/src/main/java/com/github/sergiofgonzalez/wconf/WaterfallConfig.java
+++ b/src/main/java/com/github/sergiofgonzalez/wconf/WaterfallConfig.java
@@ -19,6 +19,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
@@ -31,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.typesafe.config.Config;
+import com.typesafe.config.ConfigException;
 import com.typesafe.config.ConfigFactory;
 import static com.github.sergiofgonzalez.wconf.MetaConfigKeys.*;
 
@@ -227,6 +229,62 @@ public class WaterfallConfig {
 		}
 		LOGGER.debug("Access to config {} to read {} took {}", uniqueInstance.instanceUUID, key, Duration.between(start, Instant.now()));		
 		return value;
+	}
+	
+	/**
+	 * Obtains the string representation of a configuration parameter
+	 * 
+	 * @param key the key of the configuration parameter to retrieve
+	 * @return optional of string value associated to key
+	 */
+	public Optional<String> getOrElse(String key) {
+		return getConfig(key, null);
+	}
+	
+	/**
+	 * Obtains the string representation of a configuration parameter
+	 * 
+	 * @param key the key of the configuration parameter to retrieve
+	 * @param defaultValue the value to return if no configuration for key is present
+	 * @return optional of string value associated to key
+	 */
+	public Optional<String> getOrElse(String key, String defaultValue) {
+		return getConfig(key, defaultValue);
+	}
+	
+	/**
+	 * @param key the key of the configuration parameter to retrieve
+	 * @param defaultValue the value to return if no configuration for key is present
+	 * @return optional of string value associated to key
+	 */
+	public Optional<String> getConfig(String key, String defaultValue){
+		Instant start = Instant.now();
+		if(key!=null && !key.equals("")) {
+			try {
+				String value = uniqueInstance.config.getString(key);
+
+				if (value.startsWith("cipher(") && value.endsWith(")")) {
+					if (!isEncryptionEnabled) {
+						throw new IllegalStateException("Encryption has not been enabled.");
+					}
+					String cipherText = value.substring(7, value.length() - 1);
+					byte[] clearBytes;
+					try {
+						clearBytes = cipher.doFinal(Base64.getDecoder().decode(cipherText));
+					} catch (IllegalBlockSizeException | BadPaddingException e) {
+						LOGGER.error("Error trying to decrypt key {}", key);
+						throw new IllegalArgumentException("Could not decrypt config value", e);
+					}
+					value = new String(clearBytes, StandardCharsets.UTF_8);
+				}
+				LOGGER.debug("Access to config {} to read {} took {}", uniqueInstance.instanceUUID, key, Duration.between(start, Instant.now()));		
+				return Optional.of(value);
+			}catch(ConfigException ex) {
+				return (defaultValue!=null)?Optional.of(defaultValue):Optional.empty();
+			}
+		}else {
+			throw new IllegalArgumentException("Key is null or empty");
+		}
 	}
 	
 	/**

--- a/src/test/java/com/github/sergiofgonzalez/test/WaterfallConfigNegativeTests.java
+++ b/src/test/java/com/github/sergiofgonzalez/test/WaterfallConfigNegativeTests.java
@@ -1,0 +1,51 @@
+package com.github.sergiofgonzalez.test;
+
+import static com.github.sergiofgonzalez.wconf.WaterfallConfig.wconf;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import com.github.sergiofgonzalez.test.utils.categories.ActiveTest;
+
+/**
+ * Things to check:
+ * [ ] Throw IllegalArgumentException if null value is provided in key
+ * [ ] Throw IllegalArgumentException if empty string value is provided in key
+ * [ ] Return empty value if key is not present in the config/application001.conf & environment variable & system prop
+ * [ ] Return default value if key is not present in the config/application001.conf & environment variable & system prop
+ * 
+ *
+ */
+@Category(ActiveTest.class)
+public class WaterfallConfigNegativeTests {
+
+	@BeforeClass
+	public static void runOnlyOnceOnStart() {
+	}
+	
+	@Test(expected = IllegalArgumentException.class)
+	public void testWaterfallConfigGetWithNullKey() {
+		wconf().getOrElse(null);
+	}
+	
+	@Test(expected = IllegalArgumentException.class)
+	public void testWaterfallConfigGetWithEmptyKey() {
+		wconf().getOrElse("");
+	}
+	
+	@Test
+	public void testWaterfallConfigGetWithPropNotDefined() {
+		Optional<String> value = wconf().getOrElse("prop_not_defined");
+		assertThat(value).isEmpty();
+	}
+	
+	@Test
+	public void testWaterfallConfigGetWithPropNotDefinedWithDefaultValue() {
+		Optional<String> value = wconf().getOrElse("prop_not_defined", "default_value");
+		assertThat(value.get()).isEqualTo("default_value");
+	}
+}


### PR DESCRIPTION
Resolved in : AAAWA-18179
Added a null and empty string check, added try-catch for "key not present in config" scenario, added default value code for "key not present in config" scenario ,  added a new test class with negative tests.
files changed
UPDATED : WaterfallConfig.java    -  added methods ---getOrElse(String key)  ,   getOrElse(String key, String defaultValue)    ,   getConfig(String key, String defaultValue)
ADDED : WaterfallConfigNegativeTests.java