### PR TITLE
Allow single path specification for external config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ but it can also be specified using environment variables and properties using th
 Setting the value of `wconf_ext_app_properties_paths` in the application-level property file will have **no effect**, as this value is needed in creation time while the application level property source is being discovered.  
   
 ## Syntax for Configuration Files
-The syntax for configuration files is a JSON superset called *HOCON* that is used by the library doing all the heavy lifting for *wconf* (see [Typesafehub Config](https://github.com/typesafehub/config#user-content-using-hocon-the-json-superset).
+The syntax for configuration files is a JSON superset called *HOCON* that is used by the library doing all the heavy lifting for *wconf* (see [Typesafehub Config](https://github.com/typesafehub/config#user-content-using-hocon-the-json-superset)).
 
 *HOCON* allows you to use plain java-style properties if that is what you like:
 ```
@@ -141,7 +141,7 @@ You can find examples of profile usage in the test section.
 ## Encrypted Properties
 A recurring requirement for configuration properties is the support of symmetric encryption for sensible data such as datasource passwords.
 
-*wconf* features support for flexible encryption of configuration properties using the Java Cryptography Extension (JCE). Please note that you should be aware of the best practices and recommendations when using this feature, as symmetric encryption is useless is the key is handled carelessly (distributed without proper control or committed to your source code repository).
+*wconf* features support for flexible encryption of configuration properties using the Java Cryptography Extension (JCE). Please note that you should be aware of the best practices and recommendations when using this feature, as symmetric encryption is useless if the key is handled carelessly (distributed without proper control or committed to your source code repository).
 
 **Note**
 + The keystore and key found in the test section is provided for **demonstration purposes** and should **not** be used in applications.
@@ -210,7 +210,7 @@ If you don't know how to generate an *"encrypted and then encoded in Base64 valu
 ## Reserved Configuration Property Names
 The configuration properties used to configure *wconf* are always prepended with `wconf_` and are reserved.
 
-The current list all these reserved property names and their descriptions:
+The following table lists all these reserved property names and their descriptions:
 
 | Reserved Property Name | Description | Default|
 |------------------------|-------------|--------|
@@ -226,7 +226,7 @@ The current list all these reserved property names and their descriptions:
 | wconf_encryption.key_store.key.alias | the key alias, that is the string, used to identify the key to use for the symmetric encryption from the ones defined in the key store,  e.g.wconf-secret-key | n/a |
 | wconf_encryption.key_store.key.password | the password key that provides access to the key to use for the symmetric encryption, e.g. mykeypasswd | n/a |
 
-Note that the variables susceptible of being overridden by environment variables do not use `.` as there are operating systems that prevent variables such as `profile.active` from being defined.
+Note that the variables susceptible of being overridden by environment variables do not use `.` as there are operating systems that do not allow environment variable names such as `profile.active` from being defined.
 
 ## Implementation Details and Recommendations
 *wconf* is defined as an eagerly-loaded singleton that loads and preconfigures the *Typesafehub Config* framework according to a set of predefined choices.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Modify your `pom.xml` to add a dependency for *wconf*:
     <dependency>
       <groupId>com.accenture</groupId>
       <artifactId>waterfall-config</artifactId>
-      <version>1.1.0</version>
+      <version>1.1.1</version>
     </dependency>
 ```
 
@@ -78,7 +78,14 @@ but it can also be specified using environment variables and properties using th
 -D wconf_ext_app_properties_paths.1="./tmp/" \
 -D wconf_ext_app_properties_paths.2="./shared-volume/"
 ```
-  
+
+and for simplicity, you can also specify a single path, when passing an array in the command-line represents a problem:
+
+```
+-D wconf_ext_app_properties_paths="./shared-volume/"
+```
+
+
 **Note**
 Setting the value of `wconf_ext_app_properties_paths` in the application-level property file will have **no effect**, as this value is needed in creation time while the application level property source is being discovered.  
   

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   
   <groupId>com.accenture</groupId>
   <artifactId>waterfall-config</artifactId>
-  <version>1.1.0</version>
+  <version>1.1.1-SNAPSHOT</version>
 
   <packaging>jar</packaging>  
 
@@ -124,6 +124,7 @@
             
             <!-- Scanning of External Paths Tests -->
             <include>WaterfallConfigExtPathTests</include>
+            <include>WaterfallConfigExtPathSingleValueTests</include>
             
             <!-- Multivalued Result Tests -->
             <include>WaterfallConfigMultiValuedTests</include>

--- a/src/main/java/com/accenture/wconf/WaterfallConfig.java
+++ b/src/main/java/com/accenture/wconf/WaterfallConfig.java
@@ -1,6 +1,16 @@
 package com.accenture.wconf;
 
-import static com.accenture.wconf.MetaConfigKeys.*;
+import static com.accenture.wconf.MetaConfigKeys.META_CONFIG_ACTIVE_PROFILE_KEY;
+import static com.accenture.wconf.MetaConfigKeys.META_CONFIG_APP_RESOURCE_KEY;
+import static com.accenture.wconf.MetaConfigKeys.META_CONFIG_ENCRYPTION_ALGORITHM_KEY;
+import static com.accenture.wconf.MetaConfigKeys.META_CONFIG_ENCRYPTION_IV_KEY;
+import static com.accenture.wconf.MetaConfigKeys.META_CONFIG_ENCRYPTION_KEY_STORE_KEY_ALIAS_KEY;
+import static com.accenture.wconf.MetaConfigKeys.META_CONFIG_ENCRYPTION_KEY_STORE_KEY_PASSWORD_KEY;
+import static com.accenture.wconf.MetaConfigKeys.META_CONFIG_ENCRYPTION_KEY_STORE_PASSWORD_KEY;
+import static com.accenture.wconf.MetaConfigKeys.META_CONFIG_ENCRYPTION_KEY_STORE_PATH_KEY;
+import static com.accenture.wconf.MetaConfigKeys.META_CONFIG_ENCRYPTION_KEY_TYPE_KEY;
+import static com.accenture.wconf.MetaConfigKeys.META_CONFIG_ENCRYPTION_SWITCH_KEY;
+import static com.accenture.wconf.MetaConfigKeys.META_CONFIG_EXT_APP_RESOURCE_ADDITIONAL_PATHS;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -23,6 +33,7 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
@@ -107,10 +118,13 @@ public class WaterfallConfig {
 		if (isEncryptionEnabled) {
 			loadEncryptionConfiguration();
 		}
+		
+
 				
 		Duration duration = Duration.between(start, Instant.now());
 		LOGGER.debug("Config initialization took {}", duration);
 		LOGGER.debug("Encryption configured: {}", isEncryptionEnabled);
+		
 	}
 	
 	private Config applyProfileToConfig(Config conf, Config applicationPropsFoundOutsideJar, Config environmentVariablesProps, Config javaSystemProps, Config applicationProps, Config commonProps) {
@@ -175,6 +189,17 @@ public class WaterfallConfig {
 		List<String> externalPaths = new ArrayList<String>();
 		if (bootstrapConfig.hasPath(META_CONFIG_EXT_APP_RESOURCE_ADDITIONAL_PATHS.toString())) {			
 			externalPaths.addAll(bootstrapConfig.getStringList(META_CONFIG_EXT_APP_RESOURCE_ADDITIONAL_PATHS.toString()));
+			if (bootstrapConfig.hasPath(META_CONFIG_EXT_APP_RESOURCE_ADDITIONAL_PATHS.toString())) {
+				if (bootstrapConfig.getAnyRef(META_CONFIG_EXT_APP_RESOURCE_ADDITIONAL_PATHS.toString()) instanceof String) {
+					externalPaths.add(bootstrapConfig.getString(META_CONFIG_EXT_APP_RESOURCE_ADDITIONAL_PATHS.toString()));
+				} else {
+				LOGGER.info("found external path ==>"+bootstrapConfig.getStringList(META_CONFIG_EXT_APP_RESOURCE_ADDITIONAL_PATHS.toString()));
+				externalPaths.addAll(bootstrapConfig.getStringList(META_CONFIG_EXT_APP_RESOURCE_ADDITIONAL_PATHS.toString()));
+				}
+			} 
+			else {
+				externalPaths.add("./");
+			}
 		} else {
 			externalPaths.add("./");
 		}

--- a/src/test/java/com/accenture/wconf/test/WaterfallConfigExtPathSingleValueTests.java
+++ b/src/test/java/com/accenture/wconf/test/WaterfallConfigExtPathSingleValueTests.java
@@ -1,0 +1,76 @@
+package com.accenture.wconf.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import com.accenture.wconf.test.utils.categories.ActiveTest;
+
+import static com.accenture.wconf.WaterfallConfig.wconf;
+import static com.accenture.wconf.test.utils.writers.ConfFileUtils.*;
+
+/**
+ * Test Cases validating the scanning of external paths to find application-level properties
+ * when only one path is passed (instead of an array)
+ *   
+ * @author sergio.f.gonzalez
+ *
+ */
+
+@Category(ActiveTest.class)
+public class WaterfallConfigExtPathSingleValueTests {
+	
+	private static final UUID uuid = UUID.randomUUID();
+	private static final String appConfFilename = String.format("/tmp/application_%s.conf", uuid.toString());
+	private static final Path extConfPath = Paths.get(appConfFilename).toAbsolutePath();
+	
+	private static final List<String> EXTERNAL_CONF_CONTENTS = Arrays.asList(
+			"wconf_active_profile: test",
+			"dev {",
+			"  value_defined_in_dev=This value has been taken from dev profile in application009.conf",
+			"  value_defined_in_all_profiles=This value has been taken from dev profile in application009.conf",
+			"}",
+			"test {",
+			"  value_defined_in_test=This value has been taken from test profile in application009.conf",
+			"  value_defined_in_all_profiles=This value has been taken from test profile in application009.conf",
+			"  in_environment_var_and_profile=This value has been taken from test profile in application009.conf",
+			"  in_java_property_and_profile=This value has been taken from test profile in application009.conf",
+			"  in_environment_var_and_java_property_and_profile=This value has been taken from test profile in application009.conf",
+			"  in_external_and_external_conf=This value has been taken from test profile in application009.conf",
+			"}",
+			"production {",
+			"  value_defined_in_production=This value has been taken from production profile in application009.conf",
+			"  value_defined_in_all_profiles=This value has been taken from production profile in application009.conf",  
+			"}",
+			"value_defined_outside_any_profile=This value has been defined in application009.conf"			
+		);
+	
+	@BeforeClass
+	public static void runOnlyOnceOnStart() {
+		deleteTestResource(extConfPath);
+		writeFileBeforeTest(extConfPath, EXTERNAL_CONF_CONTENTS);		
+		System.setProperty("wconf_app_properties", String.format("config/%s", appConfFilename));
+
+		System.setProperty("wconf_ext_app_properties_paths", "/tmp/");
+	}
+		
+	@AfterClass
+	public static void runOnlyOnceOnEnd() {
+		deleteTestResource(extConfPath);
+	}
+	
+	@Test
+	public void testReadPropOnlyDefinedInActiveProfile() {
+		String value = wconf().get("value_defined_in_test");
+		assertThat(value).isEqualTo("This value has been taken from test profile in application009.conf");		
+	}
+}


### PR DESCRIPTION
Enhancement of the existing library to support specifying a string instead of an array of strings when you only need to enable a single path.
Previously, you had to use an array even when you only had to specify a single path and that was problematic in certain scenarios in which you had to pass environment variables to set those values.